### PR TITLE
fix: constructor and access to some methods were missing in ios

### DIFF
--- a/base-asymmetric-encryption/src/iosMain/kotlin/io/iohk/atala/prism/apollo/utils/KMMEdKeyPair.kt
+++ b/base-asymmetric-encryption/src/iosMain/kotlin/io/iohk/atala/prism/apollo/utils/KMMEdKeyPair.kt
@@ -4,9 +4,8 @@ actual class KMMEdKeyPair actual constructor(
     actual val privateKey: KMMEdPrivateKey,
     actual val publicKey: KMMEdPublicKey
 ) {
-
-    actual companion object : Ed25519KeyPairGeneration {
-        override fun generateKeyPair(): KMMEdKeyPair {
+    public actual companion object : Ed25519KeyPairGeneration {
+        public override fun generateKeyPair(): KMMEdKeyPair {
             val privateKey = KMMEdPrivateKey()
             return KMMEdKeyPair(privateKey, privateKey.publicKey())
         }

--- a/base-asymmetric-encryption/src/iosMain/kotlin/io/iohk/atala/prism/apollo/utils/KMMX25519KeyPair.kt
+++ b/base-asymmetric-encryption/src/iosMain/kotlin/io/iohk/atala/prism/apollo/utils/KMMX25519KeyPair.kt
@@ -4,8 +4,8 @@ actual class KMMX25519KeyPair actual constructor(
     actual val privateKey: KMMX25519PrivateKey,
     actual val publicKey: KMMX25519PublicKey
 ) {
-    actual companion object : X25519KeyPairGeneration {
-        override fun generateKeyPair(): KMMX25519KeyPair {
+    public actual companion object : X25519KeyPairGeneration {
+        public override fun generateKeyPair(): KMMX25519KeyPair {
             val privateKey = KMMX25519PrivateKey()
             return KMMX25519KeyPair(privateKey, privateKey.publicKey())
         }

--- a/base-asymmetric-encryption/src/iosMain/kotlin/io/iohk/atala/prism/apollo/utils/KMMX25519PrivateKey.kt
+++ b/base-asymmetric-encryption/src/iosMain/kotlin/io/iohk/atala/prism/apollo/utils/KMMX25519PrivateKey.kt
@@ -2,13 +2,9 @@ package io.iohk.atala.prism.apollo.utils
 
 import swift.cryptoKit.X25519
 
-actual class KMMX25519PrivateKey {
-    public val raw: ByteArray
-
+actual class KMMX25519PrivateKey(val raw: ByteArray) {
     @Throws(RuntimeException::class)
-    constructor() {
-        this.raw = X25519.createPrivateKey().success()?.toByteArray() ?: throw RuntimeException("Null result")
-    }
+    public constructor() : this(X25519.createPrivateKey().success()?.toByteArray() ?: throw RuntimeException("Null result"))
 
     @Throws(RuntimeException::class)
     public fun publicKey(): KMMX25519PublicKey {

--- a/base-asymmetric-encryption/src/iosMain/kotlin/io/iohk/atala/prism/apollo/utils/KMMX25519PublicKey.kt
+++ b/base-asymmetric-encryption/src/iosMain/kotlin/io/iohk/atala/prism/apollo/utils/KMMX25519PublicKey.kt
@@ -1,9 +1,3 @@
 package io.iohk.atala.prism.apollo.utils
 
-actual class KMMX25519PublicKey {
-    public val raw: ByteArray
-
-    constructor(raw: ByteArray) {
-        this.raw = raw
-    }
-}
+actual class KMMX25519PublicKey(val raw: ByteArray = ByteArray(0))


### PR DESCRIPTION
Just simply there were 2 constructors missing and some companion methods were not public so not accessible in iOS.