### PR TITLE
fix: remove if since the xcframework is not building with all targets

### DIFF
--- a/apollo/build.gradle.kts
+++ b/apollo/build.gradle.kts
@@ -61,31 +61,20 @@ kotlin {
             baseName = "ApolloLibrary"
         }
     }
-//    macosX64 {
-//        swiftCinterop("IOHKSecureRandomGeneration", name)
-//        swiftCinterop("IOHKCryptoKit", name)
-//
-//        binaries.framework {
-//            baseName = "ApolloLibrary"
-//        }
-//    }
-    // Mx Chip
-    if (System.getProperty("os.arch") != "x86_64") {
-        macosArm64 {
-            swiftCinterop("IOHKSecureRandomGeneration", name)
-            swiftCinterop("IOHKCryptoKit", name)
+    macosArm64 {
+        swiftCinterop("IOHKSecureRandomGeneration", name)
+        swiftCinterop("IOHKCryptoKit", name)
 
-            binaries.framework {
-                baseName = "ApolloLibrary"
-            }
+        binaries.framework {
+            baseName = "ApolloLibrary"
         }
-        iosSimulatorArm64 {
-            swiftCinterop("IOHKSecureRandomGeneration", name)
-            swiftCinterop("IOHKCryptoKit", name)
+    }
+    iosSimulatorArm64 {
+        swiftCinterop("IOHKSecureRandomGeneration", name)
+        swiftCinterop("IOHKCryptoKit", name)
 
-            binaries.framework {
-                baseName = "ApolloLibrary"
-            }
+        binaries.framework {
+            baseName = "ApolloLibrary"
         }
     }
     js(IR) {
@@ -191,43 +180,32 @@ kotlin {
         }
         val jsTest by getting
 
-        if (os.isMacOsX) {
-            val appleMain by creating {
-                dependsOn(commonMain)
-                dependencies {
-                    implementation(project(":secp256k1-kmp"))
-                }
+        val appleMain by creating {
+            dependsOn(commonMain)
+            dependencies {
+                implementation(project(":secp256k1-kmp"))
             }
-            val appleTest by creating {
-                dependsOn(commonTest)
-            }
-            val iosMain by getting {
-                dependsOn(appleMain)
-            }
-            val iosTest by getting {
-                dependsOn(appleTest)
-            }
-//            val macosX64Main by getting {
-//                dependsOn(appleMain)
-//            }
-//            val macosX64Test by getting {
-//                dependsOn(appleTest)
-//            }
-            // Mx Chip
-            if (System.getProperty("os.arch") != "x86_64") {
-                val iosSimulatorArm64Main by getting {
-                    dependsOn(appleMain)
-                }
-                val iosSimulatorArm64Test by getting {
-                    dependsOn(appleTest)
-                }
-                val macosArm64Main by getting {
-                    dependsOn(appleMain)
-                }
-                val macosArm64Test by getting {
-                    dependsOn(appleTest)
-                }
-            }
+        }
+        val appleTest by creating {
+            dependsOn(commonTest)
+        }
+        val iosMain by getting {
+            dependsOn(appleMain)
+        }
+        val iosTest by getting {
+            dependsOn(appleTest)
+        }
+        val iosSimulatorArm64Main by getting {
+            dependsOn(appleMain)
+        }
+        val iosSimulatorArm64Test by getting {
+            dependsOn(appleTest)
+        }
+        val macosArm64Main by getting {
+            dependsOn(appleMain)
+        }
+        val macosArm64Test by getting {
+            dependsOn(appleTest)
         }
     }
 
@@ -235,11 +213,8 @@ kotlin {
         tasks.getByName<org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeSimulatorTest>("iosX64Test") {
             device.set("iPhone 14 Plus")
         }
-        // Mx Chip
-        if (System.getProperty("os.arch") != "x86_64") {
-            tasks.getByName<org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeSimulatorTest>("iosSimulatorArm64Test") {
-                device.set("iPhone 14 Plus")
-            }
+        tasks.getByName<org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeSimulatorTest>("iosSimulatorArm64Test") {
+            device.set("iPhone 14 Plus")
         }
     }
 }

--- a/secp256k1-kmp/build.gradle.kts
+++ b/secp256k1-kmp/build.gradle.kts
@@ -53,24 +53,21 @@ kotlin {
                 "$rootDir/secp256k1-kmp/native/build/ios/x86_x64-macosx/libsecp256k1.a"
             )
         }
-        // Mx Chip
-        if (System.getProperty("os.arch") != "x86_64") {
-            iosSimulatorArm64 {
-                secp256k1CInterop("iosSimulatorArm64")
-                // https://youtrack.jetbrains.com/issue/KT-39396
-                compilations["main"].kotlinOptions.freeCompilerArgs += listOf(
-                    "-include-binary",
-                    "$rootDir/secp256k1-kmp/native/build/ios/arm64-iphonesimulator/libsecp256k1.a"
-                )
-            }
-            macosArm64 {
-                secp256k1CInterop("macosArm64")
-                // https://youtrack.jetbrains.com/issue/KT-39396
-                compilations["main"].kotlinOptions.freeCompilerArgs += listOf(
-                    "-include-binary",
-                    "$rootDir/secp256k1-kmp/native/build/ios/arm64-macosx/libsecp256k1.a"
-                )
-            }
+        iosSimulatorArm64 {
+            secp256k1CInterop("iosSimulatorArm64")
+            // https://youtrack.jetbrains.com/issue/KT-39396
+            compilations["main"].kotlinOptions.freeCompilerArgs += listOf(
+                "-include-binary",
+                "$rootDir/secp256k1-kmp/native/build/ios/arm64-iphonesimulator/libsecp256k1.a"
+            )
+        }
+        macosArm64 {
+            secp256k1CInterop("macosArm64")
+            // https://youtrack.jetbrains.com/issue/KT-39396
+            compilations["main"].kotlinOptions.freeCompilerArgs += listOf(
+                "-include-binary",
+                "$rootDir/secp256k1-kmp/native/build/ios/arm64-macosx/libsecp256k1.a"
+            )
         }
     }
 
@@ -98,14 +95,11 @@ kotlin {
             val macosX64Main by getting {
                 dependsOn(nativeMain)
             }
-            // Mx Chip
-            if (System.getProperty("os.arch") != "x86_64") {
-                val iosSimulatorArm64Main by getting {
-                    dependsOn(nativeMain)
-                }
-                val macosArm64Main by getting {
-                    dependsOn(nativeMain)
-                }
+            val iosSimulatorArm64Main by getting {
+                dependsOn(nativeMain)
+            }
+            val macosArm64Main by getting {
+                dependsOn(nativeMain)
             }
         }
         all {


### PR DESCRIPTION
# Overview
We need to remove this If's since they are making that this targets are not built on xcframework final product [ATL-6264]

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [ ] Bug fixes (non-breaking change which fixes an issue)
* [ ] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [ ] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [ ] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [ ] My changes can not or do not need to be tested
* [ ] My changes can and should be tested by unit and/or integration tests
* [ ] If yes to above: I have added tests to cover my changes
* [ ] If yes to above: I have taken care to cover edge cases in my tests

[ATL-6264]: https://input-output.atlassian.net/browse/ATL-6264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ