### PR TITLE
fix: Apple crash when creating seed with empty string passphrase

### DIFF
--- a/apollo/src/appleMain/kotlin/io/iohk/atala/prism/apollo/hashing/PBKDF2SHA512.kt
+++ b/apollo/src/appleMain/kotlin/io/iohk/atala/prism/apollo/hashing/PBKDF2SHA512.kt
@@ -41,7 +41,7 @@ actual object PBKDF2SHA512 {
                     algorithm = kCCPBKDF2,
                     password = p,
                     passwordLen = p.length.convert(),
-                    salt = saltPin.addressOf(0),
+                    salt = if (saltPin.get().isNotEmpty()) saltPin.addressOf(0) else null,
                     saltLen = saltPin.get().size.convert(),
                     prf = kCCPRFHmacAlgSHA512,
                     rounds = rounds,

--- a/apollo/src/commonTest/kotlin/io/iohk/atala/prism/apollo/derivation/MnemonicTests.kt
+++ b/apollo/src/commonTest/kotlin/io/iohk/atala/prism/apollo/derivation/MnemonicTests.kt
@@ -1,0 +1,55 @@
+package io.iohk.atala.prism.apollo.derivation
+
+import kotlin.test.Test
+import kotlin.test.fail
+
+class MnemonicTests {
+    @Test
+    fun testCreatingSeedWithEmptyPassphrase() {
+        val words = listOf(
+            "bicycle",
+            "monster",
+            "swap",
+            "cave",
+            "bulk",
+            "fossil",
+            "nominee",
+            "crisp",
+            "tail",
+            "parent",
+            "fossil",
+            "eyebrow",
+            "fold",
+            "manage",
+            "custom",
+            "burst",
+            "flight",
+            "lawn",
+            "survey",
+            "snake",
+            "brown",
+            "bridge",
+            "hard",
+            "perfect"
+        )
+        val passphrase = ""
+
+        assertDoesNotThrow {
+            MnemonicHelper.Companion.createSeed(words, passphrase)
+        }
+    }
+}
+
+/**
+ * Asserts that the given executable does not throw an exception.
+ *
+ * @param block The executable function to be tested.
+ * @throws AssertionError if the executable throws any exception.
+ */
+inline fun assertDoesNotThrow(block: () -> Unit) {
+    try {
+        block()
+    } catch (e: Exception) {
+        fail("Expected no exception to be thrown, but got ${e.stackTraceToString()}")
+    }
+}


### PR DESCRIPTION
# Overview
<!-- What this PR does, and why is needed, a useful description is expected, and relevant tickets should be mentioned -->

Fixes Apple crash when creating seed with empty string passphrase

## Checklist

### My PR contains...
* [ ] No code changes (changes to documentation, CI, metadata, etc.)
* [x] Bug fixes (non-breaking change which fixes an issue)
* [ ] Improvements (misc. changes to existing features)
* [ ] Features (non-breaking change which adds functionality)

### My changes...
* [ ] are breaking changes
* [x] are not breaking changes
* [ ] If yes to above: I have updated the documentation accordingly

### Documentation
* [x] My changes do not require a change to the project documentation
* [ ] My changes require a change to the project documentation
* [ ] If yes to above: I have updated the documentation accordingly

### Tests
* [ ] My changes can not or do not need to be tested
* [x] My changes can and should be tested by unit and/or integration tests
* [x] If yes to above: I have added tests to cover my changes
* [x] If yes to above: I have taken care to cover edge cases in my tests