### PR TITLE
docs: update code owners and fix pull request template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence
-* @hamada147 
+* @elribonazo @hamada147 @goncalo-frade-iohk @yshyn-iohk @curtis-h @cristianIOHK @amagyar-iohk
 
 # Docs:
 *.md @petevielhaber

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,6 @@
-@goncalo-frade-iohk @yshyn-iohk @elribonazo @hamada147 @curtis-h @cristianIOHK @amagyar-iohk
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence
+* @hamada147 
 
+# Docs:
+*.md @petevielhaber

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,9 +5,9 @@ Summarize the changes you're submitting in a few sentences, including Jira ticke
 Link to existing ADR (Architecture Decision Record), if any. If relevant, describe other approaches explored and the selected approach. Documenting why the methods were not selected will create a knowledge base for future reference, helping prevent others from revisiting less optimal ideas.
 
 ### Checklist: 
-- [] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-apollo/blob/main/CONTRIBUTING.md) of this project
-- [] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
-- [] I have commented my code, particularly in hard-to-understand areas
-- [] I have made corresponding changes to the documentation
-- [] I have added tests that prove my fix is effective or that my feature works
-- [] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
+- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-apollo/blob/main/CONTRIBUTING.md) of this project
+- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)


### PR DESCRIPTION
### Description: 
- Code owners: define the actual codeowner as Ahmed Moussa and the content editor will be automatically added to any PR related to markdown files
- Pull request template: modify to be able to check / uncheck boxes without editing the comment

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-apollo/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
