### PR TITLE
fix:  Invalid signature integer: negative on JS platform

### DIFF
--- a/apollo/src/jsMain/kotlin/io/iohk/atala/prism/apollo/secp256k1/Secp256k1Lib.kt
+++ b/apollo/src/jsMain/kotlin/io/iohk/atala/prism/apollo/secp256k1/Secp256k1Lib.kt
@@ -97,7 +97,6 @@ actual class Secp256k1Lib actual constructor() {
             secp256k1.verify(transcoded, sha.asUint8Array(), publicKey.asUint8Array(), {})
         } catch (e: dynamic) {
             secp256k1.verify(normalised, sha.asUint8Array(), publicKey.asUint8Array(), {})
-
         }
     }
 

--- a/apollo/src/jsMain/kotlin/io/iohk/atala/prism/apollo/secp256k1/Secp256k1Lib.kt
+++ b/apollo/src/jsMain/kotlin/io/iohk/atala/prism/apollo/secp256k1/Secp256k1Lib.kt
@@ -67,7 +67,11 @@ actual class Secp256k1Lib actual constructor() {
         } catch (e: dynamic) {
             secp256k1.Signature.fromCompact(jsSignatureByteArray)
         }
-        return signature.normalizeS()
+        return if (signature.hasHighS()) {
+            signature.normalizeS()
+        } else {
+            signature
+        }
     }
 
     /**
@@ -88,8 +92,12 @@ actual class Secp256k1Lib actual constructor() {
         if (secp256k1.verify(normalised, sha.asUint8Array(), publicKey.asUint8Array(), {})) {
             return true
         }
-        val transcoded = transcodeSignatureToBitcoin(normalised.toCompactRawBytes().asByteArray())
-        return secp256k1.verify(transcoded, sha.asUint8Array(), publicKey.asUint8Array(), {})
+        return try {
+            secp256k1.verify(normalised, sha.asUint8Array(), publicKey.asUint8Array(), {})
+        } catch (e: dynamic) {
+            val transcoded = transcodeSignatureToBitcoin(normalised.toCompactRawBytes().asByteArray())
+            secp256k1.verify(transcoded, sha.asUint8Array(), publicKey.asUint8Array(), {})
+        }
     }
 
     private fun transcodeSignatureToBitcoin(signature: ByteArray): SignatureType {

--- a/apollo/src/jsMain/kotlin/io/iohk/atala/prism/apollo/secp256k1/Secp256k1Lib.kt
+++ b/apollo/src/jsMain/kotlin/io/iohk/atala/prism/apollo/secp256k1/Secp256k1Lib.kt
@@ -93,10 +93,11 @@ actual class Secp256k1Lib actual constructor() {
             return true
         }
         return try {
-            secp256k1.verify(normalised, sha.asUint8Array(), publicKey.asUint8Array(), {})
-        } catch (e: dynamic) {
             val transcoded = transcodeSignatureToBitcoin(normalised.toCompactRawBytes().asByteArray())
             secp256k1.verify(transcoded, sha.asUint8Array(), publicKey.asUint8Array(), {})
+        } catch (e: dynamic) {
+            secp256k1.verify(normalised, sha.asUint8Array(), publicKey.asUint8Array(), {})
+
         }
     }
 

--- a/apollo/src/jsTest/kotlin/io/iohk/atala/prism/apollo/utils/Secp256k1LibTestJS.kt
+++ b/apollo/src/jsTest/kotlin/io/iohk/atala/prism/apollo/utils/Secp256k1LibTestJS.kt
@@ -17,7 +17,8 @@ class Secp256k1LibTestJS {
         val signature = sk.sign(data)
         val verified = pk.verify(signature, data)
         assertEquals(
-            verified, true
+            verified,
+            true
         )
     }
 }

--- a/apollo/src/jsTest/kotlin/io/iohk/atala/prism/apollo/utils/Secp256k1LibTestJS.kt
+++ b/apollo/src/jsTest/kotlin/io/iohk/atala/prism/apollo/utils/Secp256k1LibTestJS.kt
@@ -1,0 +1,23 @@
+package io.iohk.atala.prism.apollo.utils
+
+import io.iohk.atala.prism.apollo.derivation.Mnemonic
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class Secp256k1LibTestJS {
+
+    @Test
+    fun testCreateApolloSignatureAndVerify() {
+        val mnemonics = Mnemonic.Companion.createRandomMnemonics()
+        val seed = Mnemonic.Companion.createSeed(mnemonics)
+        val secret = seed.slice(0..31).toTypedArray()
+        val sk = KMMECSecp256k1PrivateKey.Companion.secp256k1FromByteArray(secret.toByteArray())
+        val pk = sk.getPublicKey()
+        val data = "Data 0002".encodeToByteArray()
+        val signature = sk.sign(data)
+        val verified = pk.verify(signature, data)
+        assertEquals(
+            verified, true
+        )
+    }
+}


### PR DESCRIPTION
### Description: 
Adding a fix for JS signatures which result in     Invalid signature integer: negative.
Simply added a try catch and now we conditionally run the transcoding function as last resource.

All CommonMain and JSMain tests are working.
+ On top of this, have integrated the package manually in TS until I got that working :) 
we are good to go


### Checklist: 
- [ ] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-apollo/blob/main/CONTRIBUTING.md) of this project
- [ ] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
