### PR TITLE
fix: Removed references to Atala in docs and variables referred to by docs

### DIFF
--- a/.github/workflows/pr-title-validation.yml
+++ b/.github/workflows/pr-title-validation.yml
@@ -1,0 +1,14 @@
+---
+# kics-scan ignore
+name: "Validate PR title"
+
+on: [pull_request]
+
+jobs:
+  lint_pr:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,8 +12,8 @@ concurrency:
 
 env:
   JAVA_VERSION: 17
-  ATALA_GITHUB_ACTOR: ${{ secrets.ATALA_GITHUB_ACTOR }}
-  ATALA_GITHUB_TOKEN: ${{ secrets.ATALA_GITHUB_TOKEN }}
+  GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 on:
   pull_request:
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.ATALA_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: "Install Java ${{ env.JAVA_VERSION }}"
@@ -139,7 +139,7 @@ jobs:
         uses: mi-kas/kover-report@v1
         with:
           path: ${{ github.workspace }}/apollo/build/reports/kover/report.xml
-          token: ${{ secrets.ATALA_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           title: Code Coverage
           update-comment: true
           min-coverage-overall: 90

--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -8,8 +8,8 @@ defaults:
 
 env:
   JAVA_VERSION: 17
-  ATALA_GITHUB_ACTOR: ${{ secrets.ATALA_GITHUB_ACTOR }}
-  ATALA_GITHUB_TOKEN: ${{ secrets.ATALA_GITHUB_TOKEN }}
+  GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 on:
   workflow_dispatch:
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.ATALA_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: "Validate Gradle Wrapper"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,10 @@ concurrency:
 
 env:
   JAVA_VERSION: 17
-  ATALA_GITHUB_ACTOR: ${{ secrets.ATALA_GITHUB_ACTOR }}
-  GITHUB_ACTOR: ${{ secrets.ATALA_GITHUB_ACTOR }}
-  ATALA_GITHUB_TOKEN: ${{ secrets.ATALA_GITHUB_TOKEN }}
-  GITHUB_TOKEN: ${{ secrets.ATALA_GITHUB_TOKEN }}
+  GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  ATALA_NPM_TOKEN: ${{ secrets.ATALA_NPM_TOKEN }}
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
 on:
   workflow_dispatch:
@@ -30,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.ATALA_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: "Install Java ${{ env.JAVA_VERSION }}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,8 @@ and feel free to propose changes to this document in a pull request.
 ### Identus
 
 Identus platform is a self-sovereign identity (SSI) platform and service suite for verifiable data and digital identity.
-Built on Cardano, it offers core infrastructure for issuing DIDs (Decentralized identifiers) and verifiable credentials,
-alongside tools and frameworks to help expand your ecosystem.  
+Built on the Distributed Ledger, it offers core infrastructure for issuing DIDs (Decentralized identifiers) and 
+verifiable credentials, alongside tools and frameworks to help expand your ecosystem.  
 The complete platform is separated in multiple repositories:
 
 * [Apollo](https://github.com/input-output-hk/atala-prism-apollo) - Repo for the Apollo Building Block, this contains

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ and feel free to propose changes to this document in a pull request.
 ### Identus
 
 Identus platform is a self-sovereign identity (SSI) platform and service suite for verifiable data and digital identity.
-Built on the Distributed Ledger, it offers core infrastructure for issuing DIDs (Decentralized identifiers) and 
+Built on a distributed ledger, it offers core infrastructure for issuing DIDs (Decentralized identifiers) and 
 verifiable credentials, alongside tools and frameworks to help expand your ecosystem.  
 The complete platform is separated in multiple repositories:
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ A cryptography lib built with Kotlin Multiplatform with support for the followin
 
 ### Set Environment Variables
 
-Set variable `ATALA_GITHUB_ACTOR` with your GitHub Username and set variable `ATALA_GITHUB_TOKEN` with your GitHub Personal Access Token.
+Set variable `GITHUB_ACTOR` with your GitHub Username and set variable `GITHUB_TOKEN` with your GitHub Personal Access Token.
 
 As an example we will go with `Bash`
 
 1. Open CMD.
 2. Run `sudo nano $HOME/.bash_profile`.
-3. Insert `export ATALA_GITHUB_ACTOR="YOUR GITHUB USERNAME"`
-4. Insert `export ATALA_GITHUB_TOKEN="YOUR GITHUB PERSONAL ACCESS TOKEN"`
+3. Insert `export GITHUB_ACTOR="YOUR GITHUB USERNAME"`
+4. Insert `export GITHUB_TOKEN="YOUR GITHUB PERSONAL ACCESS TOKEN"`
 5. Save profile and restart CMD to take effect.
 
 ### Install Homebrew (Mac Only)

--- a/apollo/build.gradle.kts
+++ b/apollo/build.gradle.kts
@@ -828,7 +828,7 @@ npmPublish {
         access.set(NpmAccess.PUBLIC)
         register("npmjs") {
             uri.set("https://registry.npmjs.org")
-            authToken.set(System.getenv("ATALA_NPM_TOKEN"))
+            authToken.set(System.getenv("NPM_TOKEN"))
         }
     }
 }


### PR DESCRIPTION
Under https://input-output.atlassian.net/browse/ATL-6475 and according to the replacement table, references to Atala were renamed to conform with brand position.

The changes are mostly to "readme" and other md files, as changes to the code require in-depth assessment of impact by an expert of this artifact.

In cases where the instruction referred to a variable name, this was rebranded both at the instruction document and the affected automation script.
