### PR TITLE
fix: correct HDKey seed error message to report 64 bytes instead of 32

### DIFF
--- a/apollo/src/androidMain/kotlin/org/hyperledger/identus/apollo/derivation/EdHDKey.kt
+++ b/apollo/src/androidMain/kotlin/org/hyperledger/identus/apollo/derivation/EdHDKey.kt
@@ -78,7 +78,7 @@ actual class EdHDKey actual constructor(
          */
         actual fun initFromSeed(seed: ByteArray): EdHDKey {
             require(seed.size == 64) {
-                "Seed expected byte length to be ${ECConfig.PRIVATE_KEY_BYTE_SIZE}"
+                "Seed expected byte length to be ${ECConfig.SEED_BYTE_SIZE}"
             }
 
             val keySlice = seed.sliceArray(0 until 32)

--- a/apollo/src/appleMain/kotlin/org/hyperledger/identus/apollo/derivation/EdHDKey.kt
+++ b/apollo/src/appleMain/kotlin/org/hyperledger/identus/apollo/derivation/EdHDKey.kt
@@ -78,7 +78,7 @@ actual class EdHDKey actual constructor(
          */
         actual fun initFromSeed(seed: ByteArray): EdHDKey {
             require(seed.size == 64) {
-                "Seed expected byte length to be ${ECConfig.PRIVATE_KEY_BYTE_SIZE}"
+                "Seed expected byte length to be ${ECConfig.SEED_BYTE_SIZE}"
             }
 
             val keySlice = seed.sliceArray(0 until 32)

--- a/apollo/src/commonMain/kotlin/org/hyperledger/identus/apollo/derivation/HDKey.kt
+++ b/apollo/src/commonMain/kotlin/org/hyperledger/identus/apollo/derivation/HDKey.kt
@@ -107,7 +107,7 @@ class HDKey(
         childIndex = childIndex
     ) {
         require(seed.size == 64) {
-            "Seed expected byte length to be ${ECConfig.PRIVATE_KEY_BYTE_SIZE}"
+            "Seed expected byte length to be ${ECConfig.SEED_BYTE_SIZE}"
         }
     }
 
@@ -127,7 +127,7 @@ class HDKey(
         childIndex = BigIntegerWrapper(childIndex)
     ) {
         require(seed.size == 64) {
-            "Seed expected byte length to be ${ECConfig.PRIVATE_KEY_BYTE_SIZE}"
+            "Seed expected byte length to be ${ECConfig.SEED_BYTE_SIZE}"
         }
     }
 

--- a/apollo/src/commonMain/kotlin/org/hyperledger/identus/apollo/utils/ECConfig.kt
+++ b/apollo/src/commonMain/kotlin/org/hyperledger/identus/apollo/utils/ECConfig.kt
@@ -11,6 +11,7 @@ import kotlin.js.JsExport
 @JsExport
 object ECConfig {
     val PRIVATE_KEY_BYTE_SIZE: Int = 32
+    val SEED_BYTE_SIZE: Int = 64
     internal val PUBLIC_KEY_COORDINATE_BYTE_SIZE: Int = 32
     internal val PUBLIC_KEY_COMPRESSED_BYTE_SIZE: Int = PUBLIC_KEY_COORDINATE_BYTE_SIZE + 1
     val SIGNATURE_MAX_BYTE_SIZE: Int = 72

--- a/apollo/src/jsMain/kotlin/org/hyperledger/identus/apollo/derivation/EdHDKey.kt
+++ b/apollo/src/jsMain/kotlin/org/hyperledger/identus/apollo/derivation/EdHDKey.kt
@@ -72,7 +72,7 @@ actual class EdHDKey actual constructor(
          */
         actual fun initFromSeed(seed: ByteArray): EdHDKey {
             require(seed.size == 64) {
-                "Seed expected byte length to be ${ECConfig.PRIVATE_KEY_BYTE_SIZE}"
+                "Seed expected byte length to be ${ECConfig.SEED_BYTE_SIZE}"
             }
 
             val key = seed.sliceArray(0 until 32)

--- a/apollo/src/jvmMain/kotlin/org/hyperledger/identus/apollo/derivation/EdHDKey.kt
+++ b/apollo/src/jvmMain/kotlin/org/hyperledger/identus/apollo/derivation/EdHDKey.kt
@@ -78,7 +78,7 @@ actual class EdHDKey actual constructor(
          */
         actual fun initFromSeed(seed: ByteArray): EdHDKey {
             require(seed.size == 64) {
-                "Seed expected byte length to be ${ECConfig.PRIVATE_KEY_BYTE_SIZE}"
+                "Seed expected byte length to be ${ECConfig.SEED_BYTE_SIZE}"
             }
 
             val keySlice = seed.sliceArray(0 until 32)


### PR DESCRIPTION
The error message in HDKey and EdHDKey constructors was referencing ECConfig.PRIVATE_KEY_BYTE_SIZE (32 bytes) for the seed length validation message, but BIP32 HDKey derivation requires a 64-byte seed (512 bits, as produced by BIP39 PBKDF2-HMAC-SHA512).

Add a dedicated ECConfig.SEED_BYTE_SIZE = 64 constant and use it in all seed-length error messages across all platform targets.

Fixes #151

### Description: 
Summarize the changes you're submitting in a few sentences, including Jira ticket ATL-xxxx if applicable. Link to any discussion, related issues and bug reports to give the context to help the reviewer understand the PR.

### Alternatives Considered (optional): 
Link to existing ADR (Architecture Decision Record), if any. If relevant, describe other approaches explored and the selected approach. Documenting why the methods were not selected will create a knowledge base for future reference, helping prevent others from revisiting less optimal ideas.

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger-identus/apollo/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
