### PR TITLE
fix: scalar bytes for js secp256k1

### DIFF
--- a/apollo/src/jsMain/kotlin/org/hyperledger/identus/apollo/secp256k1/Secp256k1Lib.kt
+++ b/apollo/src/jsMain/kotlin/org/hyperledger/identus/apollo/secp256k1/Secp256k1Lib.kt
@@ -40,7 +40,25 @@ actual class Secp256k1Lib actual constructor() {
         val privKey = BigInteger.parseString(privKeyString, 16)
         val derivedPrivKey = BigInteger.parseString(derivedPrivKeyString, 16)
         val added = (privKey + derivedPrivKey) % ECConfig.n
-        return added.toByteArray()
+        // ionspin BigInteger.toByteArray() is minimal-length big-endian; secp256k1 secrets must be 32 bytes (left-pad zeros).
+        return normalizeSecp256k1ScalarBytes(added.toByteArray())
+    }
+
+    private fun normalizeSecp256k1ScalarBytes(bytes: ByteArray): ByteArray {
+        val n = ECConfig.PRIVATE_KEY_BYTE_SIZE
+        var b = bytes
+        while (b.size > n && b[0] == 0.toByte()) {
+            b = b.copyOfRange(1, b.size)
+        }
+        require(b.size <= n) {
+            "Secp256k1 private scalar exceeds $n bytes after normalization (${b.size})"
+        }
+        if (b.size == n) {
+            return b
+        }
+        return ByteArray(n).also { out ->
+            b.copyInto(out, destinationOffset = n - b.size)
+        }
     }
 
     /**

--- a/apollo/src/jsTest/kotlin/org/hyperledger/identus/apollo/utils/Secp256k1LibTestJS.kt
+++ b/apollo/src/jsTest/kotlin/org/hyperledger/identus/apollo/utils/Secp256k1LibTestJS.kt
@@ -1,6 +1,8 @@
 package org.hyperledger.identus.apollo.utils
 
 import org.hyperledger.identus.apollo.derivation.Mnemonic
+import org.hyperledger.identus.apollo.secp256k1.Secp256k1Lib
+import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -19,5 +21,17 @@ class Secp256k1LibTestJS {
             verified,
             true
         )
+    }
+
+    @Test
+    fun derivePrivateKey_alwaysReturns32Bytes() {
+        val lib = Secp256k1Lib()
+        val rnd = Random(42)
+        repeat(2000) { i ->
+            val a = ByteArray(32) { rnd.nextInt(256).toByte() }
+            val b = ByteArray(32) { rnd.nextInt(256).toByte() }
+            val r = lib.derivePrivateKey(a, b)
+            assertEquals(32, r!!.size, "iteration $i")
+        }
     }
 }

--- a/apollo/src/jsTest/kotlin/org/hyperledger/identus/apollo/utils/Secp256k1LibTestJS.kt
+++ b/apollo/src/jsTest/kotlin/org/hyperledger/identus/apollo/utils/Secp256k1LibTestJS.kt
@@ -2,7 +2,6 @@ package org.hyperledger.identus.apollo.utils
 
 import org.hyperledger.identus.apollo.derivation.Mnemonic
 import org.hyperledger.identus.apollo.secp256k1.Secp256k1Lib
-import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -23,15 +22,19 @@ class Secp256k1LibTestJS {
         )
     }
 
+    /**
+     * Regression: JS [derivePrivateKey] used ionspin [BigInteger.toByteArray], which is minimal-length.
+     * For (priv + tweak) % n == 1, that is a single non-zero byte — callers expect a fixed 32-byte secret.
+     * (This is unrelated to public-key 0x02/0x03/0x04 prefix bytes; those apply to encoded public points, not private scalars.)
+     */
     @Test
-    fun derivePrivateKey_alwaysReturns32Bytes() {
+    fun derivePrivateKey_leftPadsMinimalScalarTo32Bytes() {
         val lib = Secp256k1Lib()
-        val rnd = Random(42)
-        repeat(2000) { i ->
-            val a = ByteArray(32) { rnd.nextInt(256).toByte() }
-            val b = ByteArray(32) { rnd.nextInt(256).toByte() }
-            val r = lib.derivePrivateKey(a, b)
-            assertEquals(32, r!!.size, "iteration $i")
-        }
+        val priv = ByteArray(32) { 0 }.also { it[31] = 1 }
+        val tweak = ByteArray(32) { 0 }
+        val r = lib.derivePrivateKey(priv, tweak)!!
+        assertEquals(32, r.size)
+        assertEquals(0, r[0].toInt() and 0xff)
+        assertEquals(1, r[31].toInt() and 0xff)
     }
 }


### PR DESCRIPTION
### Description: 
Found a bug in `sdk-ts` that randomly we would get 31 bytes instead 32 for secp256k1

```
KeyInitializationError: 181: Invalid byte size: 32 exptected, 31 given
      at new _Secp256k1PrivateKey (sdk-ts/packages/lib/sdk/src/apollo/utils/Secp256k1PrivateKey.ts:44:17)
      at _Secp256k1PrivateKey.derive (sdk-ts/packages/lib/sdk/src/apollo/utils/Secp256k1PrivateKey.ts:72:11)
      at _class7.createPrivateKey (sdk-ts/packages/lib/sdk/src/apollo/Apollo.ts:370:15)
      at CreatePrismDID.run (sdk-ts/packages/lib/sdk/src/edge-agent/didFunctions/CreatePrismDID.ts:35:33)
      at async Proxy.run (sdk-ts/packages/lib/sdk/src/utils/tasks.ts:65:35)
      at async sdk-ts/integration-tests/e2e-tests/src/workflow/EdgeAgentWorkflow.ts:236:11
```

This fix normalizes the bytes with 0 left padding

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/hyperledger-identus/apollo/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
