### PR TITLE
fix(apollo): replace jcip annotations dependency

### DIFF
--- a/apollo/build.gradle.kts
+++ b/apollo/build.gradle.kts
@@ -123,7 +123,10 @@ kotlin {
             implementation(libs.secp256k1.kmp.android)
             implementation(libs.guava)
             implementation(libs.bouncycastle)
-            implementation(libs.bitcoinjcore)
+            implementation("org.bitcoinj:bitcoinj-core:${libs.versions.bitcoinj.get()}") {
+                exclude(group = "net.jcip", module = "jcip-annotations")
+            }
+            implementation(libs.jcip.annotations.apache)
             implementation(libs.jna.android)
         }
         jvmMain.dependencies {
@@ -131,7 +134,10 @@ kotlin {
             implementation(libs.secp256k1.kmp.jvm)
             implementation(libs.guava)
             implementation(libs.bouncycastle)
-            implementation(libs.bitcoinjcore)
+            implementation("org.bitcoinj:bitcoinj-core:${libs.versions.bitcoinj.get()}") {
+                exclude(group = "net.jcip", module = "jcip-annotations")
+            }
+            implementation(libs.jcip.annotations.apache)
             implementation(libs.jna)
         }
         jvmTest.dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ vanniktech-maven-publish = "0.33.0"
 npm-publish = "3.5.3"
 swiftpackage = "2.2.4"
 secp256k1-kmp = "0.16.0"
+bitcoinj = "0.17.1"
 android-minSdk = "24"
 android-compileSdk = "34"
 
@@ -19,7 +20,8 @@ atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version = "0.23.2" }
 macs-hmac-sha2 = { module = "org.kotlincrypto.macs:hmac-sha2", version = "0.3.0" }
 hash-hmac-sha2 = { module = "org.kotlincrypto.hash:sha2", version = "0.4.0" }
 bouncycastle = { module = "org.bouncycastle:bcprov-jdk18on", version = "1.80"}
-bitcoinjcore = { module = "org.bitcoinj:bitcoinj-core", version = "0.17" }
+bitcoinjcore = { module = "org.bitcoinj:bitcoinj-core", version.ref = "bitcoinj" }
+jcip-annotations-apache = { module = "com.github.stephenc.jcip:jcip-annotations", version = "1.0-1" }
 kotlin-web = { module = "org.jetbrains.kotlin-wrappers:kotlin-web", version = "1.0.0-pre.461"}
 kotlin-node = { module = "org.jetbrains.kotlin-wrappers:kotlin-node", version = "18.11.13-pre.461"}
 junit = { module = "junit:junit", version = "4.13.2" }


### PR DESCRIPTION
## Summary
- bump `org.bitcoinj:bitcoinj-core` from `0.17` to `0.17.1`
- exclude `net.jcip:jcip-annotations` from the bitcoinj dependency
- add `com.github.stephenc.jcip:jcip-annotations:1.0-1` as the Apache-licensed replacement for JVM and Android source sets

## Why
Apollo issue #192 tracks the licensing problem caused by the transitive runtime dependency on `net.jcip:jcip-annotations`.

The upstream bitcoinj change referenced in the issue comments exists in commit `8070bd80e6897684d004137a388990b75e946c2f`, but the latest published artifact available today, `org.bitcoinj:bitcoinj-core:0.17.1`, still ships the `net.jcip:jcip-annotations:1.0` runtime dependency. This PR fixes Apollo now without waiting for a future bitcoinj release.

## Validation
- `./gradlew :apollo:dependencies --configuration jvmRuntimeClasspath`
  - confirms `org.bitcoinj:bitcoinj-core:0.17.1` is present
  - confirms `net.jcip:jcip-annotations` is no longer present
  - confirms `com.github.stephenc.jcip:jcip-annotations:1.0-1` is present instead
- `./gradlew :apollo:compileKotlinJvm --no-configuration-cache --max-workers=1`
  - did not fail in Apollo dependency resolution
  - is currently blocked by an existing unrelated native wrapper failure in `:bip32-ed25519:buildRustWrapper` (`lipo: can't move temporary file ... libuniffi_ed25519_bip32_wrapper.dylib.lipo`)

## Follow-up
Once bitcoinj publishes a release that includes the upstream removal of `net.jcip:jcip-annotations`, Apollo should be able to simplify this by dropping the explicit exclusion and replacement dependency.

Fixes #192
