### PR TITLE
fix(release): include ed25519_bip32_wasm.js in the published npm tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,9 +136,25 @@ jobs:
           ORG_GRADLE_PROJECT_autoRelease: true
         run: ./gradlew publishToMavenCentral --no-configuration-cache
 
+      - name: NPM publish smoke test
+        if: ${{ inputs.release_ts }}
+        # Guard against a regression of 6c8640f: assert that
+        # ed25519_bip32_wasm.js is in the tarball before publishing,
+        # since a published version cannot be replaced on npm.
+        run: |
+          set -euo pipefail
+          STAGE_DIR=./apollo/build/packages/js
+          [ -d "$STAGE_DIR" ] || { echo "::error::$STAGE_DIR does not exist" >&2; exit 1; }
+          PACK_DIR=$(mktemp -d)
+          npm pack "$STAGE_DIR" --pack-destination "$PACK_DIR" >/dev/null
+          tar -tzf "$PACK_DIR"/*.tgz | grep -q '^package/ed25519_bip32_wasm\.js$' \
+            || { echo "::error::ed25519_bip32_wasm.js is missing from the npm tarball" >&2; tar -tzf "$PACK_DIR"/*.tgz >&2; exit 1; }
+          echo "smoke test ok: ed25519_bip32_wasm.js is in the tarball"
+          rm -rf "$PACK_DIR"
+
       - name: NPM publish
         if: ${{ inputs.release_ts }}
-        run: npm publish ./apollo/build/packages/js --access public
+        run: ./gradlew :apollo:publishJsPackageToNpmjsRegistry
 
       - uses: crazy-max/ghaction-import-gpg@v6
         id: import-gpg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,7 +154,7 @@ jobs:
 
       - name: NPM publish
         if: ${{ inputs.release_ts }}
-        run: ./gradlew :apollo:publishJsPackageToNpmjsRegistry
+        run: npm publish ./apollo/build/packages/js --access public
 
       - uses: crazy-max/ghaction-import-gpg@v6
         id: import-gpg

--- a/apollo/build.gradle.kts
+++ b/apollo/build.gradle.kts
@@ -293,6 +293,14 @@ tasks.withType<NpmPublishTask>().configureEach {
     dependsOn("npmBip32Wasm")
 }
 
+// Make the wasm file part of the assembled package so the build dir is
+// complete regardless of whether npm publish is invoked via gradle or
+// the npm CLI. Restores the chain severed in 6c8640f (which broke the
+// 1.8.5 release by shipping a tarball missing ed25519_bip32_wasm.js).
+tasks.named("assembleJsPackage") {
+    dependsOn("npmBip32Wasm")
+}
+
 val swiftPackageUpdateMinOSVersion =
     tasks.register("updateMinOSVersion") {
         group = "multiplatform-swift-package"


### PR DESCRIPTION
### Description

The 1.8.5 npm release of `@hyperledger/identus-apollo` shipped a tarball missing `ed25519_bip32_wasm.js`. The file is required at runtime by `apollo.js` (line 2497 of the bundled output does `require('./ed25519_bip32_wasm.js')`), and consumers fail at module load with `Cannot find module './ed25519_bip32_wasm.js'`. Observed in the Identus `integration` test suite against `identus-sdk@8.0.0-rc.10`, which transitively pulls `identus-apollo@^1.4.5` and resolves to the broken 1.8.5.

**Root cause** — commit [6c8640f](https://github.com/hyperledger-identus/apollo/commit/6c8640f64547c001912704c9478327c250d31c8f) ("fix(release): use npm OIDC publishing") switched the release workflow's NPM publish step from a gradle task (`./gradlew :apollo:publishJsPackageToNpmjsRegistry`) to a plain `npm publish` shell command. The `npmBip32Wasm` task (which copies the wasm artifact into `apollo/build/packages/js/`) was only wired as a `dependsOn` of `NpmPublishTask` from the `dev.petuska.npm.publish` gradle plugin, so bypassing that task severed the chain. The build directory at publish time no longer contained `ed25519_bip32_wasm.js`, but the require call in `apollo.js` was still there.

### Changes

* **`apollo/build.gradle.kts`** — add `tasks.named("assembleJsPackage") { dependsOn("npmBip32Wasm") }`. This makes the staged build directory complete on its own, regardless of whether the publish step is invoked via gradle or the npm CLI. Mirrors the pattern already used for `jsBrowserProductionLibraryDistribution` and `jsNodeProductionLibraryDistribution` (which both depend on `copyBip32Wasm`).

* **`.github/workflows/release.yml`** — add an "NPM publish smoke test" step that runs `npm pack` on the staged directory and asserts `ed25519_bip32_wasm.js` is in the tarball. Harmless under the current gradle-based publish; fails loudly if a future change bypasses the gradle task again. This is regression protection, not a fix in its own right.

### How to verify the fix locally

After this lands, a release run should produce an npm tarball that contains `ed25519_bip32_wasm.js`. You can confirm by downloading the artifact from the workflow's `npmBip32Wasm` task output, or by inspecting the published tarball:

```sh
npm view @hyperledger/identus-apollo@1.8.6 dist.tarball | xargs curl -sSL | tar -tz | grep ed25519
# expected: package/ed25519_bip32_wasm.js
```

### Checklist

- [x] My PR follows the contribution guidelines of this project
- [x] My PR is free of third-party dependencies that don't comply with the Allowlist
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation *(no user-facing doc change needed)*
- [x] I have added tests that prove my fix is effective or that my feature works *(release smoke test)*
- [x] I have checked the PR title to follow the conventional commit specification

### Related

* Bug-introducing commit: [6c8640f](https://github.com/hyperledger-identus/apollo/commit/6c8640f64547c001912704c9478327c250d31c8f) on `release/1.8.5`
* Consumer impact: `hyperledger-identus/integration` test runs 27255955264 and 27277022285 (the first hit this in the wild via `identus-sdk@8.0.0-rc.10` → `identus-apollo@1.8.5`)